### PR TITLE
Feat: 카카오 로그인 구현#23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,15 @@ dependencies {
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+	implementation 'org.hibernate.validator:hibernate-validator'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/SingSongGame/BE/BeApplication.java
+++ b/src/main/java/SingSongGame/BE/BeApplication.java
@@ -1,5 +1,6 @@
 package SingSongGame.BE;
 
+import SingSongGame.BE.config.DotenvLoader;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class BeApplication {
 
 	public static void main(String[] args) {
+		DotenvLoader.loadEnv();
 		SpringApplication.run(BeApplication.class, args);
 	}
 

--- a/src/main/java/SingSongGame/BE/auth/application/AuthService.java
+++ b/src/main/java/SingSongGame/BE/auth/application/AuthService.java
@@ -1,7 +1,93 @@
 package SingSongGame.BE.auth.application;
 
+import SingSongGame.BE.auth.application.dto.response.LoginResponse;
+import SingSongGame.BE.auth.application.dto.response.TokenResponse;
+import SingSongGame.BE.auth.persistence.AuthRepository;
+import SingSongGame.BE.auth.persistence.User;
+import SingSongGame.BE.common.util.CookieUtil;
+import SingSongGame.BE.common.util.JwtProvider;
+import SingSongGame.BE.user.persistence.UserRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.core.env.Environment;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
+import java.util.Map;
+
 @Service
+@RequiredArgsConstructor
 public class AuthService {
+
+    private final AuthRepository authRepository;
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final Environment env;
+
+    private static final String DEFAULT_IMAGE_URL = "";
+
+    public LoginResponse handleOAuthLogin(OAuth2User oAuth2User, HttpServletResponse response) {
+
+        Map<String, Object> kakaoAccount = oAuth2User.getAttribute("kakao_account");
+        String email = (String) kakaoAccount.get("email");
+
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        String imageUrl = (profile != null) ? (String) profile.get("profile_image_url") : DEFAULT_IMAGE_URL;
+
+
+        User user = authRepository.findByEmail(email)
+                .orElseGet(() -> registerUser(email, imageUrl));
+
+
+        String accessToken = jwtProvider.createAccessToken(user);
+        String refreshToken = jwtProvider.createRefreshToken(user);
+
+
+        boolean isSecure = !Arrays.asList(env.getActiveProfiles()).contains("dev");
+
+        CookieUtil.addSameSiteCookie(response, "access_token", accessToken, isSecure);
+        CookieUtil.addSameSiteCookie(response, "refresh_token", refreshToken, isSecure);
+
+
+
+
+        return new LoginResponse(
+                accessToken,
+                refreshToken,
+                user.isFirstLogin(),
+                user.getId(),
+                user.getEmail()
+        );
+    }
+
+    public TokenResponse reissue(String refreshToken) {
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token");
+        }
+
+        Claims claims = jwtProvider.parseClaims(refreshToken);
+        String email = claims.getSubject();
+
+        User user = authRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        String newAccessToken = jwtProvider.createAccessToken(user);
+
+        return new TokenResponse(newAccessToken, user.getId());
+    }
+
+    private User registerUser(String email, String imageUrl) {
+        User user = User.builder()
+                .email(email)
+                .imageUrl(imageUrl)
+                .name(null)
+                .isFirstLogin(true)
+                .build();
+
+        return userRepository.save(user);
+    }
 }

--- a/src/main/java/SingSongGame/BE/auth/application/dto/response/LoginResponse.java
+++ b/src/main/java/SingSongGame/BE/auth/application/dto/response/LoginResponse.java
@@ -1,0 +1,10 @@
+package SingSongGame.BE.auth.application.dto.response;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        boolean isFirstLogin,
+        Long userId,
+        String email
+)
+{}

--- a/src/main/java/SingSongGame/BE/auth/application/dto/response/TokenResponse.java
+++ b/src/main/java/SingSongGame/BE/auth/application/dto/response/TokenResponse.java
@@ -1,0 +1,7 @@
+package SingSongGame.BE.auth.application.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        Long userId
+) {
+}

--- a/src/main/java/SingSongGame/BE/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/SingSongGame/BE/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package SingSongGame.BE.auth.filter;
+
+import SingSongGame.BE.auth.persistence.User;
+import SingSongGame.BE.common.util.JwtProvider;
+import SingSongGame.BE.user.persistence.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+
+        String token = jwtProvider.extractTokenFromCookie(request);
+        System.out.println("🔥 요청 URI: " + request.getRequestURI());
+        System.out.println("🔥 access_token 쿠키: " + token);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Long userId = jwtProvider.getUserIdFromToken(token);
+            User user = userRepository.findById(userId).orElse(null);
+            System.out.println("✅ userId: " + userId);
+
+            if (user != null) {
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(user, null, List.of());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                System.out.println("✅ 인증 객체 설정 완료: " + user.getEmail());
+            }
+            System.out.println("[DEBUG] 토큰: " + token);
+            System.out.println("[DEBUG] 유저 ID: " + userId);
+            System.out.println("[DEBUG] 인증 성공 여부: " + (user != null));
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/SingSongGame/BE/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/SingSongGame/BE/auth/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,51 @@
+package SingSongGame.BE.auth.handler;
+
+import SingSongGame.BE.auth.application.AuthService;
+import SingSongGame.BE.auth.application.dto.response.LoginResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final AuthService authService;
+
+    @Value("${FRONTEND_REDIRECT_URL_LOCAL}")
+    private String localRedirectBase;
+
+    @Value("${FRONTEND_REDIRECT_URL_PROD}")
+    private String prodRedirectBase;
+
+    private final Environment environment;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        LoginResponse loginResponse = authService.handleOAuthLogin(oAuth2User, response);
+
+        boolean isProd = Arrays.asList(environment.getActiveProfiles()).contains("prod");
+        String baseUrl = isProd ? prodRedirectBase : localRedirectBase;
+
+        String redirectUri = loginResponse.isFirstLogin()
+                ? baseUrl + "/nickname"
+                : baseUrl + "/lobby";
+
+        System.out.println("로그인 완료 - isFirstLogin: " + loginResponse.isFirstLogin());
+        System.out.println("리다이렉트 URI: " + redirectUri);
+
+        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+    }
+}

--- a/src/main/java/SingSongGame/BE/auth/persistence/AuthRepository.java
+++ b/src/main/java/SingSongGame/BE/auth/persistence/AuthRepository.java
@@ -3,6 +3,9 @@ package SingSongGame.BE.auth.persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AuthRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/SingSongGame/BE/auth/persistence/User.java
+++ b/src/main/java/SingSongGame/BE/auth/persistence/User.java
@@ -6,10 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @Builder
 public class User {
 
@@ -25,8 +23,14 @@ public class User {
     @Column(nullable = false)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Builder.Default
+    private boolean isFirstLogin = true;
 
     //@Column(nullable = false)
     private String imageUrl;

--- a/src/main/java/SingSongGame/BE/auth/presentation/AuthController.java
+++ b/src/main/java/SingSongGame/BE/auth/presentation/AuthController.java
@@ -1,37 +1,65 @@
 package SingSongGame.BE.auth.presentation;
 
+import SingSongGame.BE.auth.application.AuthService;
+import SingSongGame.BE.auth.application.dto.response.TokenResponse;
+import SingSongGame.BE.auth.persistence.User;
+import SingSongGame.BE.common.annotation.LoginUser;
 import SingSongGame.BE.common.response.ApiResponse;
+import SingSongGame.BE.common.response.ApiResponseBody;
 import SingSongGame.BE.common.response.ApiResponseBody.SuccessBody;
 import SingSongGame.BE.common.response.ApiResponseGenerator;
 import SingSongGame.BE.common.response.MessageCode;
+import SingSongGame.BE.common.util.CookieUtil;
+
+import SingSongGame.BE.user.application.UserService;
+import SingSongGame.BE.user.application.dto.request.NameRequest;
+import SingSongGame.BE.user.application.dto.response.UserResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
 
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    @Operation(
-            summary = "로그인을 한다.",
-            description = "카카오 Oauth 2.0을 통해 로그인을 진행한다. " +
-                    "첫 유저일 경우, 카카오 로그인 및 회원가입을 동시에 진행 후 닉네임 설정 화면으로 리다이렉트, " +
-                    "기존 유저일 경우, 바로 게임 대기실로 리다이렉트"
-    )
-    @PostMapping("/login")
-    public ApiResponse<SuccessBody<Void>> login() {
-        // 구현 필요
-        return ApiResponseGenerator.success(HttpStatus.CREATED, MessageCode.LOGIN);
+    private final AuthService authService;
+
+    private final UserService userService;
+
+    private final Environment environment;
+
+    public AuthController(AuthService authService, UserService userService, Environment environment) {
+        this.authService = authService;
+        this.userService = userService;
+        this.environment = environment;
     }
+
+//    @Operation(
+//            summary = "로그인을 한다.",
+//            description = "카카오 Oauth 2.0을 통해 로그인을 진행한다. " +
+//                    "첫 유저일 경우, 카카오 로그인 및 회원가입을 동시에 진행 후 닉네임 설정 화면으로 리다이렉트, " +
+//                    "기존 유저일 경우, 바로 게임 대기실로 리다이렉트"
+//    )
+//    @PostMapping("/login")
+//    public ApiResponse<SuccessBody<Void>> login() {
+//        return ApiResponseGenerator.success(HttpStatus.CREATED, MessageCode.LOGIN);
+//    }
 
     @Operation(
             summary = "로그아웃한다.",
             description = "쿠키에 담긴 리프레시 토큰을 이용하여 로그아웃한다.")
     @PostMapping("/logout")
-    public ApiResponse<SuccessBody<Void>> logout() {
-        // 구현 필요
+    public ApiResponse<SuccessBody<Void>> logout(HttpServletResponse response) {
+        boolean isSecure = !Arrays.asList(environment.getActiveProfiles()).contains("dev");
+
+        CookieUtil.expireCookieWithSameSite(response, "refresh_token", isSecure);
+
         return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.LOGOUT);
     }
 
@@ -39,11 +67,27 @@ public class AuthController {
             summary = "토큰을 재발급한다.",
             description = "쿠키에 담긴 사용자 토큰을 이용하여 리프레시 토큰을 반환한다.")
     @PostMapping("/reissue")
-    public ApiResponse<SuccessBody<Void>> reissue() {
-        // 구현 필요
+    public ApiResponse<SuccessBody<Void>> reissue(@CookieValue("refresh_token") String refreshToken) {
+        TokenResponse token = authService.reissue(refreshToken);
         return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.REISSUE);
     }
 
+    @PatchMapping("/nickname")
+    public ApiResponse<ApiResponseBody.SuccessBody<UserResponse>> setNickname(
+            @RequestBody NameRequest request,
+            @LoginUser User user) {
 
+        User updatedUser = userService.updateName(user.getId(), request.getName());
+        return ApiResponseGenerator.success(
+                new UserResponse(updatedUser),
+                HttpStatus.OK,
+                MessageCode.UPDATE
+        );
+    }
+
+    @GetMapping("/nickname")
+    public ResponseEntity<Void> nicknamePing() {
+        return ResponseEntity.ok().build();
+    }
 
 }

--- a/src/main/java/SingSongGame/BE/common/annotation/LoginUser.java
+++ b/src/main/java/SingSongGame/BE/common/annotation/LoginUser.java
@@ -1,0 +1,11 @@
+package SingSongGame.BE.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/src/main/java/SingSongGame/BE/common/response/ApiResponseGenerator.java
+++ b/src/main/java/SingSongGame/BE/common/response/ApiResponseGenerator.java
@@ -21,4 +21,5 @@ public class ApiResponseGenerator {
         return new ApiResponse<>(
                 new ApiResponseBody.FailureBody(String.valueOf(status.value()), code, message), status);
     }
+
 }

--- a/src/main/java/SingSongGame/BE/common/response/MessageCode.java
+++ b/src/main/java/SingSongGame/BE/common/response/MessageCode.java
@@ -7,7 +7,9 @@ public enum MessageCode {
     DELETE("200", "삭제 성공"),
     LOGIN("200", "로그인 성공"),
     LOGOUT("200", "로그아웃 성공"),
-    REISSUE("200", "ACCESS TOKEN 재발급 성공");
+    REISSUE("200", "ACCESS TOKEN 재발급 성공"),
+    SUCCESS("200", "요청 성공");
+
 
     private final String code;
     private final String message;

--- a/src/main/java/SingSongGame/BE/common/util/CookieUtil.java
+++ b/src/main/java/SingSongGame/BE/common/util/CookieUtil.java
@@ -1,0 +1,53 @@
+package SingSongGame.BE.common.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+    private static final int REFRESH_TOKEN_EXPIRATION_SECONDS = 14 * 24 * 60 * 60;
+
+    public static void addSameSiteCookie(HttpServletResponse response, String name, String value, boolean secure) {
+        StringBuilder cookie = new StringBuilder();
+        cookie.append(name).append("=").append(value).append(";");
+        cookie.append(" Path=/;");
+        cookie.append(" Max-Age=").append(REFRESH_TOKEN_EXPIRATION_SECONDS).append(";");
+        cookie.append(" HttpOnly;");
+        if (secure) {
+            cookie.append(" Secure;");
+            cookie.append(" SameSite=None;"); // ✅ 배포용
+        } else {
+            cookie.append(" SameSite=Lax;"); // ✅ 로컬에서는 이게 안전함
+        }
+        System.out.println("[Set-Cookie] " + cookie.toString());
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static void deleteSameSiteCookie(HttpServletResponse response, String name, boolean secure) {
+        StringBuilder cookie = new StringBuilder();
+        cookie.append(name).append("=;");
+        cookie.append(" Path=/;");
+        cookie.append(" Max-Age=0;");
+        cookie.append(" HttpOnly;");
+        if (secure) {
+            cookie.append(" Secure;");
+        }
+        cookie.append(" SameSite=None;");
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static void expireCookieWithSameSite(HttpServletResponse response, String name, boolean secure) {
+        StringBuilder cookie = new StringBuilder();
+        cookie.append(name).append("=;");
+        cookie.append(" Path=/;");
+        cookie.append(" Max-Age=0;");
+        cookie.append(" HttpOnly;");
+        if (secure) {
+            cookie.append(" Secure;");
+        }
+        cookie.append(" SameSite=None;");
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+}

--- a/src/main/java/SingSongGame/BE/common/util/JwtProvider.java
+++ b/src/main/java/SingSongGame/BE/common/util/JwtProvider.java
@@ -1,0 +1,96 @@
+package SingSongGame.BE.common.util;
+
+
+import SingSongGame.BE.auth.persistence.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private Key getSigningKey() {
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(User user) {
+        return Jwts.builder()
+                .setSubject(user.getEmail())
+                .claim("userId", user.getId())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(User user) {
+        return Jwts.builder()
+                .setSubject(user.getEmail())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public String extractTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals("access_token")) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.get("userId", Long.class);
+    }
+}

--- a/src/main/java/SingSongGame/BE/config/DotenvLoader.java
+++ b/src/main/java/SingSongGame/BE/config/DotenvLoader.java
@@ -1,0 +1,18 @@
+package SingSongGame.BE.config;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+public class DotenvLoader {
+
+    public static void loadEnv() {
+        Dotenv dotenv = Dotenv.configure()
+                .directory("./")
+                .filename(".env")
+                .ignoreIfMissing()
+                .load();
+
+        dotenv.entries().forEach(entry ->
+                System.setProperty(entry.getKey(), entry.getValue())
+        );
+    }
+}

--- a/src/main/java/SingSongGame/BE/config/LoginUserArgumentResolver.java
+++ b/src/main/java/SingSongGame/BE/config/LoginUserArgumentResolver.java
@@ -1,0 +1,45 @@
+package SingSongGame.BE.config;
+
+import SingSongGame.BE.auth.persistence.User;
+import SingSongGame.BE.common.annotation.LoginUser;
+import SingSongGame.BE.common.util.JwtProvider;
+import SingSongGame.BE.user.application.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class) &&
+                parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        String token = jwtProvider.extractTokenFromCookie(request); // 쿠키에서 토큰 추출
+        if (token == null) {
+            return null;
+        }
+
+        Long userId = jwtProvider.getUserIdFromToken(token);
+        return userService.findById(userId);
+    }
+}

--- a/src/main/java/SingSongGame/BE/config/SecurityConfig.java
+++ b/src/main/java/SingSongGame/BE/config/SecurityConfig.java
@@ -1,21 +1,45 @@
 package SingSongGame.BE.config;
 
+import SingSongGame.BE.auth.filter.JwtAuthenticationFilter;
+import SingSongGame.BE.auth.handler.OAuth2LoginSuccessHandler;
+import SingSongGame.BE.common.util.JwtProvider;
+import SingSongGame.BE.user.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
+        return http
             .csrf(csrf -> csrf.disable())
+            .cors(Customizer.withDefaults())
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll()
-            );
-        return http.build();
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                    .requestMatchers("/api/auth/nickname").authenticated()
+                    .requestMatchers("/api/**").permitAll()
+                    .anyRequest().authenticated()
+            )
+                .oauth2Login(oauth -> oauth
+                        .loginPage("/login")
+                        .successHandler(oAuth2LoginSuccessHandler)
+                )
+            .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, userRepository),
+                UsernamePasswordAuthenticationFilter.class)
+                .build();
     }
 } 

--- a/src/main/java/SingSongGame/BE/config/WebConfig.java
+++ b/src/main/java/SingSongGame/BE/config/WebConfig.java
@@ -1,23 +1,68 @@
 package SingSongGame.BE.config;
 
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
-public class WebConfig {
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "http://43.201.134.183:3000",
+                "https://singsonggame.store"
+        ));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowedMethods(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization", "Set-Cookie")); // 필요시 추가
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
+
+
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://43.201.134.183:3000")
+                        .allowedOrigins("http://localhost:3000", "http://43.201.134.183:3000", "https://singsonggame.store")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*")
                         .allowCredentials(true);
             }
         };
+    }
+
+    // 로그인 -> cors 등록 -> 스프링 시큐리티 -> cors 등록 안됨
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+    }
+
+    @PostConstruct
+    public void init() {
+        System.out.println("✅ [DEBUG] WebConfig loaded: CORS filter registered.");
     }
 }

--- a/src/main/java/SingSongGame/BE/user/application/UserService.java
+++ b/src/main/java/SingSongGame/BE/user/application/UserService.java
@@ -1,0 +1,28 @@
+package SingSongGame.BE.user.application;
+
+import SingSongGame.BE.auth.persistence.User;
+import SingSongGame.BE.user.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User findById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다. id=" + id));
+    }
+
+    @Transactional
+    public User updateName(Long userId, String username) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다"));
+
+        user.setName(username);
+        return user; // save 생략 가능 (영속성 컨텍스트 내부에서 자동 반영)
+    }
+}

--- a/src/main/java/SingSongGame/BE/user/application/dto/request/NameRequest.java
+++ b/src/main/java/SingSongGame/BE/user/application/dto/request/NameRequest.java
@@ -1,0 +1,10 @@
+package SingSongGame.BE.user.application.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NameRequest {
+    private String name;
+}

--- a/src/main/java/SingSongGame/BE/user/application/dto/response/UserResponse.java
+++ b/src/main/java/SingSongGame/BE/user/application/dto/response/UserResponse.java
@@ -1,0 +1,14 @@
+package SingSongGame.BE.user.application.dto.response;
+
+import SingSongGame.BE.auth.persistence.User;
+
+public record UserResponse(
+        Long id,
+        String email,
+        String nickname,
+        String profileImage
+) {
+    public UserResponse(User user) {
+        this(user.getId(), user.getEmail(), user.getName(), user.getImageUrl());
+    }
+}

--- a/src/main/java/SingSongGame/BE/user/persistence/UserRepository.java
+++ b/src/main/java/SingSongGame/BE/user/persistence/UserRepository.java
@@ -1,0 +1,10 @@
+package SingSongGame.BE.user.persistence;
+
+import SingSongGame.BE.auth.persistence.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByName(String username);
+}

--- a/src/main/java/SingSongGame/BE/user/presentaion/UserController.java
+++ b/src/main/java/SingSongGame/BE/user/presentaion/UserController.java
@@ -1,0 +1,25 @@
+package SingSongGame.BE.user.presentaion;
+import SingSongGame.BE.common.response.MessageCode;
+import SingSongGame.BE.auth.persistence.User;
+import SingSongGame.BE.common.annotation.LoginUser;
+import SingSongGame.BE.common.response.ApiResponse;
+import SingSongGame.BE.common.response.ApiResponseBody;
+import SingSongGame.BE.common.response.ApiResponseGenerator;
+import SingSongGame.BE.user.application.dto.response.UserResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+
+    @GetMapping("/me")
+    public ApiResponse<ApiResponseBody.SuccessBody<UserResponse>> getMyInfo(@LoginUser User user) {
+        UserResponse response = new UserResponse(user);
+        return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.SUCCESS);
+    }
+
+
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,8 +1,11 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/singsong_db
 spring.datasource.username=root
-spring.datasource.password=
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=create
-spring.jpa.properties.hibernate.show_sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.datasource.password=qaz@137988
+
+spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
+spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+spring.security.oauth2.client.registration.kakao.redirect-uri=${DEV_KAKAO_REDIRECT_URL}
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.client-name=kakao
+spring.security.oauth2.client.registration.kakao.scope=account_email,profile_image

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,4 +1,11 @@
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
+spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+spring.security.oauth2.client.registration.kakao.redirect-uri=${PROD_KAKAO_REDIRECT_URL}
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.client-name=kakao
+spring.security.oauth2.client.registration.kakao.scope=account_email,profile_image

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,17 @@
 spring.application.name=BE
 spring.profiles.active=dev
 
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+jwt.secret-key=${JWT_SECRET_KEY}
+jwt.access-token-expiration=3600000
+jwt.refresh-token-expiration=1209600000


### PR DESCRIPTION
카카오 로그인 & 닉네임 설정 구현 완료했습니다.
다만 닉네임 설정 후 다음 접속시 로비로 바로 접근하는 로직을 설계했는데 확실한 로직이 아니라 불안정합니다.(리팩토링 필요)

각 properties 파일에 카카오 API 관련 Line들 추가했습니다. 

각 API 키들이나 JWT SECRET KEY들은 .env 파일에서 관리하겠습니다