### PR TITLE
Feat: Song 도메인 기본 구축#52

### DIFF
--- a/src/main/java/SingSongGame/BE/song/application/SongService.java
+++ b/src/main/java/SingSongGame/BE/song/application/SongService.java
@@ -1,0 +1,7 @@
+package SingSongGame.BE.song.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class SongService {
+}

--- a/src/main/java/SingSongGame/BE/song/application/dto/response/SongResponse.java
+++ b/src/main/java/SingSongGame/BE/song/application/dto/response/SongResponse.java
@@ -1,0 +1,12 @@
+package SingSongGame.BE.song.application.dto.response;
+
+import java.util.List;
+
+public record SongResponse(
+        Long id,
+        String title,
+        String artist,
+        String audioUrl,
+        List<String> tags,
+        String hint
+) {}

--- a/src/main/java/SingSongGame/BE/song/persistence/Song.java
+++ b/src/main/java/SingSongGame/BE/song/persistence/Song.java
@@ -1,0 +1,42 @@
+package SingSongGame.BE.song.persistence;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Song {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;             // 예: "Attention"
+    private String artist;            // 예: "NewJeans"
+
+    @Column(name = "audio_url", length = 1000)
+    private String audioUrl;          // S3 URL
+
+    @Column(columnDefinition = "TEXT")
+    private String lyrics;            // 전체 가사
+
+    @ManyToMany
+    @JoinTable(
+            name = "song_tag",
+            joinColumns = @JoinColumn(name = "song_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private List<Tag> tags = new ArrayList<>();              // "2023,댄스,여자 가수,여자 아이돌"
+
+    @Column(length = 255)
+    private String hint;              // 예: "a_______"
+
+    @Column(length = 255)
+    private String answer;            // 예: "attention"
+}

--- a/src/main/java/SingSongGame/BE/song/persistence/SongRepository.java
+++ b/src/main/java/SingSongGame/BE/song/persistence/SongRepository.java
@@ -1,0 +1,6 @@
+package SingSongGame.BE.song.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SongRepository extends JpaRepository<Song, Long> {
+}

--- a/src/main/java/SingSongGame/BE/song/persistence/Tag.java
+++ b/src/main/java/SingSongGame/BE/song/persistence/Tag.java
@@ -1,0 +1,15 @@
+package SingSongGame.BE.song.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Tag {      // Song에 들어갈 Tag. Song과 대다대 관계를 가짐
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+}

--- a/src/main/java/SingSongGame/BE/song/persistence/TagRepository.java
+++ b/src/main/java/SingSongGame/BE/song/persistence/TagRepository.java
@@ -1,0 +1,6 @@
+package SingSongGame.BE.song.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/SingSongGame/BE/song/presentation/SongController.java
+++ b/src/main/java/SingSongGame/BE/song/presentation/SongController.java
@@ -1,0 +1,4 @@
+package SingSongGame.BE.song.presentation;
+
+public class SongController {
+}


### PR DESCRIPTION
# !필독! Song 디렉토리의 구조 및 역할 정리해드리겠습니다 

## `SongService`
- 비즈니스 로직 담당
- 예: 태그 조건에 맞는 랜덤 노래 조회, 곡 상세 정보 반환 등

## `SongResponse`
- 클라이언트에 반환할 응답 포맷를 정의한 record 파일입니다
- 예: `title`, `artist`, `audiourl`, `hint`, `answer` 등을 포함한 응답 객체

## `Song`
- 노래 도메인 엔티티
- DB 테이블 매핑
- 필드 : 제목, 가수, 오디오 URL, 가사, 태그(List), 힌트, 정답 등

## `SongRepository`
- 노래 조회용 JPA 쿼리 정의
- 예: 태그로 필터, 랜덤 조회 등

## `SongController`
- REST API 진입점
- API 메소드 구현은 아직 안했습니다.


## `Tag`
- 태그 도메인 객체 (Class로 구현했습니다)
- 예: `여자 아이돌`, `2022`, `댄스`, `발라드` 등의 분류

## `TagRepository`
- 태그 조회용 JPA 리포지토리
